### PR TITLE
[Fix] End session for cancel and stop intent

### DIFF
--- a/lambda/custom/index.js
+++ b/lambda/custom/index.js
@@ -274,10 +274,12 @@ const CancelAndStopIntentHandler = {
             }
           }
         })
+        .withShouldEndSession(true)
         .getResponse();
     } else {
       return handlerInput.responseBuilder
         .speak(speechText)
+        .withShouldEndSession(true)
         .getResponse();
     }
   },


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add fix to end session for cancel and stop intent, which previously will remain open and user cannot terminate the skill.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
